### PR TITLE
Add bitfunk versioning plugin to derive version from git tags

### DIFF
--- a/.github/workflows/ci-build-snapshot-version.yml
+++ b/.github/workflows/ci-build-snapshot-version.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-snapshot-version:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     strategy:
       matrix:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Set up Python 3.9

--- a/.github/workflows/ci-publish-release.yml
+++ b/.github/workflows/ci-publish-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-release:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     strategy:
       matrix:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Set up Python 3.9

--- a/.github/workflows/ci-pull-request-validation.yml
+++ b/.github/workflows/ci-pull-request-validation.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   pull-request-validation:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup Android SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...mai
 
 ### Bumped
 
-- Koin 3.2.3 -> 3.3.0
+- Koin 3.2.3 -> 3.3.0 and Koin Android 3.2.3 -> 3.3.1
+- Mockk 1.12.5 -> 1.13.3
 
 ## [0.1.0](https://github.com/wmontwe/blueprint-mobile/releases/tag/v0.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [semantic versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased](https://github.com/wmontwe/blueprint-mobile/releases/latest)
 
-See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...main)
+See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.1.0...main)
 
 ### Added
 
@@ -21,6 +21,7 @@ See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...mai
 - Koin 3.2.3 -> 3.3.0 and Koin Android 3.2.3 -> 3.3.1
 - Mockk 1.12.5 -> 1.13.3
 - Android Desugar 1.1.8 -> 1.2.2
+- Bitfunk Quality 0.1.1 -> 0.1.2
 
 ## [0.1.0](https://github.com/wmontwe/blueprint-mobile/releases/tag/v0.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [semantic versioning](http://semver.org/spec/v2.0.0.html
 
 See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...main)
 
+### Added
+
+- Bitfunk Versioning 0.1.2
+
 ## [0.1.0](https://github.com/wmontwe/blueprint-mobile/releases/tag/v0.1.0)
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...mai
 
 - Koin 3.2.3 -> 3.3.0 and Koin Android 3.2.3 -> 3.3.1
 - Mockk 1.12.5 -> 1.13.3
+- Android Desugar 1.1.8 -> 1.2.2
 
 ## [0.1.0](https://github.com/wmontwe/blueprint-mobile/releases/tag/v0.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ See [changeset](https://github.com/wmontwe/blueprint-mobile/compare/v0.0.1...mai
 
 - Bitfunk Versioning 0.1.2
 
+### Bumped
+
+- Koin 3.2.3 -> 3.3.0
+
 ## [0.1.0](https://github.com/wmontwe/blueprint-mobile/releases/tag/v0.1.0)
 
 Initial release

--- a/TEMPLATE_CHANGELOG.md
+++ b/TEMPLATE_CHANGELOG.md
@@ -45,7 +45,6 @@ See [changeset](PROJECT_GITHUB_LINK/compare/v0.0.1...main)
 
 - for explanation how to migrate when BREAKING changes got introduced
 
-
 ## [0.1.0](PROJECT_GITHUB_LINK//releases/tag/v0.1.0)
 
 Example release

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -21,11 +21,11 @@ PROJECT_DESCRIPTION
 
 This is a blank template to get started. First replace following placeholders:
 
-* PROJECT_TITLE
-* PROJECT_DESCRIPTION
-* PROJECT_GITHUB_LINK
-* PROJECT_WEBPAGE_URL
-* PROJECT_SONARCLOUD_NAME
+- PROJECT_TITLE
+- PROJECT_DESCRIPTION
+- PROJECT_GITHUB_LINK
+- PROJECT_WEBPAGE_URL
+- PROJECT_SONARCLOUD_NAME
 
 Assets could be placed under `docs/src/assets/` folder and images should be placed in `docs/src/assets/images/`.
 

--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -61,6 +61,8 @@ android {
     lint {
         warningsAsErrors = true
         abortOnError = true
+
+        baseline = file("lint-baseline.xml")
     }
 }
 

--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -1,3 +1,6 @@
+import eu.bitfunk.gradle.plugin.tool.versioning.version
+import eu.bitfunk.gradle.plugin.tool.versioning.versionCode
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -13,8 +16,8 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
 
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = versionCode()
+        versionName = version()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app-android/lint-baseline.xml
+++ b/app-android/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (7.3.1)" variant="all" version="7.3.1">
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 31 (current min is 21): `dynamicDarkColorScheme`"
+        errorLine1="        useDynamicColors &amp;&amp; darkTheme -> dynamicDarkColorScheme(LocalContext.current)"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/eu/bitfunk/blueprint/mobile/android/app/ui/theme/Theme.kt"
+            line="56"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 31 (current min is 21): `dynamicLightColorScheme`"
+        errorLine1="        useDynamicColors &amp;&amp; !darkTheme -> dynamicLightColorScheme(LocalContext.current)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/eu/bitfunk/blueprint/mobile/android/app/ui/theme/Theme.kt"
+            line="57"
+            column="43"/>
+    </issue>
+
+</issues>

--- a/app-android/src/androidTest/java/eu/bitfunk/blueprint/mobile/android/app/ExampleInstrumentedTest.kt
+++ b/app-android/src/androidTest/java/eu/bitfunk/blueprint/mobile/android/app/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package eu.bitfunk.blueprint.mobile.android.app
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
+import kotlin.test.assertEquals
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app-android/src/main/java/eu/bitfunk/blueprint/mobile/android/app/ui/theme/Color.kt
+++ b/app-android/src/main/java/eu/bitfunk/blueprint/mobile/android/app/ui/theme/Color.kt
@@ -20,15 +20,14 @@ package eu.bitfunk.blueprint.mobile.android.app.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val Purple80 = Color(color = 0xFFD0BCFF)
+val PurpleGrey80 = Color(color = 0xFFCCC2DC)
+val Pink80 = Color(color = 0xFFEFB8C8)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val Purple40 = Color(color = 0xFF6650a4)
+val PurpleGrey40 = Color(color = 0xFF625b71)
+val Pink40 = Color(color = 0xFF7D5260)
 
 object BlueprintColors {
     val debug = Color.Magenta
 }
-

--- a/app-android/src/test/java/eu/bitfunk/blueprint/mobile/android/app/ExampleUnitTest.kt
+++ b/app-android/src/test/java/eu/bitfunk/blueprint/mobile/android/app/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package eu.bitfunk.blueprint.mobile.android.app
 
 import org.junit.Test
-
-import org.junit.Assert.*
+import kotlin.test.assertEquals
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,3 +36,9 @@ tasks.named<Wrapper>("wrapper") {
     gradleVersion = libs.versions.gradle.get()
     distributionType = Wrapper.DistributionType.ALL
 }
+
+spotless {
+    kotlinGradle{
+        targetExclude("**/build/")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,9 +36,3 @@ tasks.named<Wrapper>("wrapper") {
     gradleVersion = libs.versions.gradle.get()
     distributionType = Wrapper.DistributionType.ALL
 }
-
-spotless {
-    kotlinGradle{
-        targetExclude("**/build/")
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.sqldelight) apply false
 
     alias(libs.plugins.bitfunk.quality)
+    alias(libs.plugins.bitfunk.versioning)
 
     id("eu.bitfunk.gradle.plugin.quality.updates")
 }

--- a/config/detekt/baseline.yml
+++ b/config/detekt/baseline.yml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ComplexCondition:Dangerfile.df.kts$!isFeatureBranch &amp;&amp; !isReleaseBranch &amp;&amp; !isDependabotBranch &amp;&amp; !isRenovateBranch</ID>
+    <ID>SwallowedException:TestAssetsLoader.kt$exception: Throwable</ID>
+    <ID>UnnecessaryAbstractClass:BaseComposeTest.kt$BaseComposeTest$BaseComposeTest</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/config/detekt/baseline.yml
+++ b/config/detekt/baseline.yml
@@ -5,5 +5,6 @@
     <ID>ComplexCondition:Dangerfile.df.kts$!isFeatureBranch &amp;&amp; !isReleaseBranch &amp;&amp; !isDependabotBranch &amp;&amp; !isRenovateBranch</ID>
     <ID>SwallowedException:TestAssetsLoader.kt$exception: Throwable</ID>
     <ID>UnnecessaryAbstractClass:BaseComposeTest.kt$BaseComposeTest$BaseComposeTest</ID>
+    <ID>UseRequire:TestContentResolverSaver.kt$throw IllegalArgumentException("ContentResolver failed to insert: $contentUri")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -10,6 +10,7 @@ build:
 config:
   validation: true
   warningsAsErrors: false
+  checkExhaustiveness: false
   # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
   excludes: ''
 
@@ -78,15 +79,21 @@ comments:
     searchInInnerClass: true
     searchInInnerObject: true
     searchInInnerInterface: true
+    searchInProtectedClass: false
   UndocumentedPublicFunction:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedFunction: false
   UndocumentedPublicProperty:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedProperty: false
 
 complexity:
   active: true
+  CognitiveComplexMethod:
+    active: false
+    threshold: 15
   ComplexCondition:
     active: true
     threshold: 4
@@ -95,7 +102,8 @@ complexity:
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
-  ComplexMethod:
+    ignoreOverloaded: false
+  CyclomaticComplexMethod:
     active: true
     threshold: 15
     ignoreSingleWhenExpression: false
@@ -387,6 +395,8 @@ performance:
   SpreadOperator:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnnecessaryPartOfBinaryExpression:
+    active: false
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -413,8 +423,6 @@ potential-bugs:
       - 'java.util.HashSet'
       - 'java.util.LinkedHashMap'
       - 'java.util.HashMap'
-  DuplicateCaseInWhenExpression:
-    active: true
   ElseCaseInsteadOfExhaustiveWhen:
     active: false
   EqualsAlwaysReturnsTrueOrFalse:
@@ -429,12 +437,16 @@ potential-bugs:
     active: true
   IgnoredReturnValue:
     active: true
-    restrictToAnnotatedMethods: true
+    restrictToConfig: true
     returnValueAnnotations:
       - '*.CheckResult'
       - '*.CheckReturnValue'
     ignoreReturnValueAnnotations:
       - '*.CanIgnoreReturnValue'
+    returnValueTypes:
+      - 'kotlin.sequences.Sequence'
+      - 'kotlinx.coroutines.flow.*Flow'
+      - 'java.util.stream.*Stream'
     ignoreFunctionCall: []
   ImplicitDefaultLocale:
     active: true
@@ -456,16 +468,13 @@ potential-bugs:
   MissingPackageDeclaration:
     active: false
     excludes: ['**/*.kts']
-  MissingWhenCase:
-    active: true
-    allowElseExpression: true
   NullCheckOnMutableProperty:
     active: false
   NullableToStringCall:
     active: false
-  RedundantElseInWhen:
-    active: true
   UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullCheck:
     active: false
   UnnecessaryNotNullOperator:
     active: true
@@ -489,6 +498,8 @@ potential-bugs:
 
 style:
   active: true
+  AlsoCouldBeApply:
+    active: false
   CanBeNonNullable:
     active: false
   CascadingCallWrapping:
@@ -500,7 +511,8 @@ style:
     active: false
   DataClassContainsFunctions:
     active: false
-    conversionFunctionPrefix: 'to'
+    conversionFunctionPrefix:
+      - 'to'
   DataClassShouldBeImmutable:
     active: false
   DestructuringDeclarationWithTooManyEntries:
@@ -532,14 +544,10 @@ style:
   ForbiddenMethodCall:
     active: false
     methods:
-      - 'kotlin.io.print'
-      - 'kotlin.io.println'
-  ForbiddenPublicDataClass:
-    active: true
-    excludes: ['**']
-    ignorePackages:
-      - '*.internal'
-      - '*.internal.*'
+      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.print'
+      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.println'
   ForbiddenSuppress:
     active: false
     rules: []
@@ -551,13 +559,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     ignoreActualFunction: true
-    excludedFunctions: ''
-  LibraryCodeMustSpecifyReturnType:
-    active: true
-    excludes: ['**']
-  LibraryEntitiesShouldNotBePublic:
-    active: true
-    excludes: ['**']
+    excludedFunctions: []
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1
@@ -592,12 +594,16 @@ style:
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false
+    excludeRawStrings: true
   MayBeConst:
     active: true
   ModifierOrder:
     active: true
   MultilineLambdaItParameter:
     active: false
+  MultilineRawStringIndentation:
+    active: false
+    indentSize: 4
   NestedClassesVisibility:
     active: true
   NewLineAtEndOfFile:
@@ -627,7 +633,8 @@ style:
   ReturnCount:
     active: true
     max: 2
-    excludedFunctions: 'equals'
+    excludedFunctions:
+      - 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true
     excludeGuardClauses: false
@@ -642,6 +649,8 @@ style:
     max: 2
     excludeGuardClauses: false
   TrailingWhitespace:
+    active: false
+  TrimMultilineRawString:
     active: false
   UnderscoresInNumericLiterals:
     active: false
@@ -665,6 +674,7 @@ style:
     active: false
   UnnecessaryParentheses:
     active: false
+    allowForUnclearPrecedence: false
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
@@ -699,6 +709,8 @@ style:
     active: true
   UseRequireNotNull:
     active: true
+  UseSumOfInsteadOfFlatMapSize:
+    active: false
   UselessCallOnNotNull:
     active: true
   UtilityClassWithPublicConstructor:

--- a/docs/develop/badges.md
+++ b/docs/develop/badges.md
@@ -22,7 +22,6 @@ Latest release:
 curl "https://img.shields.io/badge/Release-0.1.0-blueviolet.svg?style=flat"  -s -o ../assets/images/badge-release-latest.svg
 ```
 
-
 License:
 
 ```bash

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ targetSdk = "33"
 compileSdk = "33"
 
 android-gradlePlugin = "7.3.1"
-android-desugaring = "1.1.8"
+android-desugaring = "1.2.2"
 
 androidx-core = "1.9.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ android-test-kakaoCompose = "0.1.1"
 ## Gradle plugins
 plugin-version-update = "0.44.0"
 plugin-binary-compatibility-validator = "0.12.1"
-plugin-bitfunk-quality = "0.1.1"
+plugin-bitfunk-quality = "0.1.2"
 plugin-bitfunk-versioning = "0.1.2"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ android-test-kakaoCompose = "0.1.1"
 plugin-version-update = "0.44.0"
 plugin-binary-compatibility-validator = "0.12.1"
 plugin-bitfunk-quality = "0.1.1"
+plugin-bitfunk-versioning = "0.1.2"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -116,6 +117,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 version-update = { id = "com.github.ben-manes.versions", version.ref = "plugin-version-update" }
 binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "plugin-binary-compatibility-validator" }
 bitfunk-quality = { id = "eu.bitfunk.gradle.plugin.quality", version.ref = "plugin-bitfunk-quality" }
+bitfunk-versioning = { id = "eu.bitfunk.gradle.plugin.tool.versioning", version.ref = "plugin-bitfunk-versioning" }
 sqldelight = { id = "com.squareup.sqldelight", version.ref = "sqldelight" }
 mkdocs = { id = "ru.vyarus.mkdocs", version.ref = "mkdocs" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ androidx-navigation-compose = "2.5.3"
 androidx-lifecycle-viewmodel-compose = "2.5.1"
 
 # Libraries
-koin = "3.2.3"
+koin = "3.3.0"
 ktor = "2.2.1"
 sqldelight = "1.5.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,12 +30,13 @@ androidx-lifecycle-viewmodel-compose = "2.5.1"
 
 # Libraries
 koin = "3.3.0"
+koin-android = "3.3.1"
 ktor = "2.2.1"
 sqldelight = "1.5.4"
 
 # Android Test
 test-jUnit = "4.13.2"
-test-mockk = "1.12.5"
+test-mockk = "1.13.3"
 test-robolectric = "4.9.1"
 test-turbine = "0.12.1"
 
@@ -75,7 +76,7 @@ androidx-compose-navigation = { module = "androidx.navigation:navigation-compose
 androidx-compose-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-viewmodel-compose" }
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
-koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin-android" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
 koin-test-junit5 = { module = "io.insert-koin:koin-test-junit5", version.ref = "koin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,3 @@ include("docs")
 include(
     "app-android"
 )
-


### PR DESCRIPTION
## 🚀 Description

Git tags should be used to version the app and therefore the bifunk versioning plugin is used

### Bumped

- Koin 3.2.3 -> 3.3.0 and Koin Android 3.2.3 -> 3.3.1
- Mockk 1.12.5 -> 1.13.3
- Android Desugar 1.1.8 -> 1.2.2
- Bitfunk Quality 0.1.1 -> 0.1.2

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### ✅ Checklist

- [x] My code follows the code style and naming conventions of this project.
- [x] I have updated the documentation (if appropriate).
- [x] I have updated the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
